### PR TITLE
Fix longestPalindrome spec

### DIFF
--- a/test/03-bonus-problems-spec.js
+++ b/test/03-bonus-problems-spec.js
@@ -41,7 +41,7 @@ const { kth, newAlphabet, longestPalindrome, longestSubstr, maxSubarr, coinChang
         it('should determine the length of the longest palindrome that can be built with an inputted string', () => {
             expect(longestPalindrome("abccccdd")).to.equal(7);
             expect(longestPalindrome('aabccerrz')).to.equal(7);
-            expect(longestPalindrome('abcde')).to.equal(0);
+            expect(longestPalindrome('abcde')).to.equal(1);
             expect(longestPalindrome('abcdee')).to.equal(3);
         })
     })


### PR DESCRIPTION
The minimum longest palindrome of an arbitrary non-empty string is 1. For example, "a" is a palindrom in "abcde".